### PR TITLE
request.body.string doesn't work with Unicorn in operation

### DIFF
--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -64,8 +64,9 @@ private
       # this is what happens:
       # respond_with Comment::Update::JSON.run(params.merge(comment: request.body.string))
       concept_name = operation_class.model_class.to_s.underscore # this could be renamed to ::concept_class soon.
+      request_body = request.body.respond_to?(:string) ? request.body.string : request.body.read
 
-      params.merge!(concept_name => request.body.string)
+      params.merge!(concept_name => request_body)
     end
 
     res, @operation = yield # Create.run(params)


### PR DESCRIPTION
We've run into the issue, which looks similar to [roar-rails#18](https://github.com/apotonick/roar-rails/issues/18):

When trying to setup a create action like this:

```ruby
  def create
    respond_to do |format|
      run Offer::Create do |op|
        format.js { return render :create }
      end

      format.js { render :new }
    end
  end
```

I've got this error:

```ruby
NoMethodError: undefined method `string' for #<Unicorn::TeeInput:0x007fc0e46b2fe0>
```

Backtrace:

```ruby
/gems/trailblazer-0.1.2/lib/trailblazer/operation/controller.rb:68 in "operation!"
/gems/trailblazer-0.1.2/lib/trailblazer/operation/controller.rb:41 in "run"
/app/controllers/offers_controller.rb:14 in "block in create"
/gems/actionpack-4.1.8/lib/action_controller/metal/mime_responds.rb:433 in "call"
/gems/actionpack-4.1.8/lib/action_controller/metal/mime_responds.rb:433 in "retrieve_collector_from_mimes"
/gems/actionpack-4.1.8/lib/action_controller/metal/mime_responds.rb:256 in "respond_to"
/app/controllers/offers_controller.rb:13 in "create"
...
```

However, switching `request.body` to use `read` instead of `string` helps with Unicorn. I'm leaving `string` when `request.body` responds to it.