### PR TITLE
Feature/process params in ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,39 @@ end
 
 Another action is `:find` (which is currently doing the same as `:update`) to find a model by using `params[:id]`.
 
+
+### Normalizing params
+
+Override #process_params! to add or remove values to params before the operation is run.
+
+```ruby
+require 'trailblazer/operation/crud'
+
+class Comment < ActiveRecord::Base
+  class Create < Trailblazer::Operation
+    include CRUD
+    model Comment, :create
+
+    contract do
+      # ..
+    end
+
+    def process(params)
+      validate(params[:comment]) do |f|
+        f.save
+      end
+    end
+
+  private
+    def process_params!(params)
+      params.merge!(rating: params[:rating]) if params[:rating]
+    end
+  end
+end
+```
+
+This centralizes params normalization and doesn't require you to do that manually in `#process`.
+
 ### Background Processing
 
 To run an operation in Sidekiq (ActiveJob-support coming!) all you need to do is include the `Worker` module.

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -46,7 +46,6 @@ module Trailblazer
         contract_class.class_eval(&block)
       end
 
-
     private
       def build_operation_class(*params)
         class_builder.call(*params) # Uber::Builder::class_builder
@@ -54,7 +53,6 @@ module Trailblazer
     end
 
     include Uber::Builder
-
 
     def initialize(options={})
       @valid            = true
@@ -65,6 +63,8 @@ module Trailblazer
     #   Operation.run(body: "Fabulous!") #=> [true, <Comment body: "Fabulous!">]
     def run(*params)
       setup!(*params) # where do we assign/find the model?
+
+      process_params!(*params)
 
       [process(*params), valid?].reverse
     end
@@ -83,6 +83,9 @@ module Trailblazer
     end
 
   private
+
+    def process_params!(*params)
+    end
 
     def setup!(*params)
       @model = model!(*params)

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -7,6 +7,38 @@ module Comparable
   end
 end
 
+class OperationRunTestt < MiniTest::Spec
+  class Operation1 < Trailblazer::Operation
+    # allow providing your own contract.
+    self.contract_class = class Contract
+      def initialize(*)
+      end
+      def validate(params)
+        return false if params[:valid] == false
+        "local #{params}"
+      end
+
+      def errors
+        Struct.new(:to_s).new("Op just calls #to_s on Errors!")
+      end
+
+      include Comparable
+      self
+    end
+
+    def process(params)
+      model = Object
+      validate(params, model)
+    end
+
+    def process_params!(params)
+      params.merge!(garrett: "Rocks!")
+    end
+  end
+
+  let (:operation) { Operation1.new.extend(Comparable) }
+  it { Operation1.run({valid: true}).must_equal  ["local #{ {valid: true, garrett: "Rocks!"} }", operation] }
+end
 
 class OperationRunTest < MiniTest::Spec
   class Operation < Trailblazer::Operation
@@ -93,7 +125,6 @@ class OperationRunTest < MiniTest::Spec
   it { Operation.(true).contract.must_equal contract }
 end
 
-
 class OperationTest < MiniTest::Spec
   class Operation < Trailblazer::Operation
     def process(params)
@@ -172,7 +203,6 @@ class OperationTest < MiniTest::Spec
   # ::[]
   it { OperationWithManualValid.(Object).must_equal(Object) }
 
-
   # re-assign params
   class OperationReassigningParams < Trailblazer::Operation
     def process(params)
@@ -183,7 +213,6 @@ class OperationTest < MiniTest::Spec
 
   # ::run
   it { OperationReassigningParams.run({:title => "Day Like This"}).must_equal [true, "Day Like This"] }
-
 
   # #invalid!(result)
   class OperationCallingInvalid < Trailblazer::Operation
@@ -205,7 +234,6 @@ class OperationTest < MiniTest::Spec
   end
 
   it { OperationCallingInvalidWithoutResult.run(true).must_equal [false, OperationCallingInvalidWithoutResult.new] }
-
 
   # calling return from #validate block leaves result true.
   class OperationUsingReturnInValidate < Trailblazer::Operation
@@ -229,7 +257,6 @@ class OperationTest < MiniTest::Spec
   it { OperationUsingReturnInValidate.run(true).must_equal [true, 1] }
   it { OperationUsingReturnInValidate.run(false).must_equal [false, 2] }
 
-
   # unlimited arguments for ::run and friends.
   class OperationReceivingLottaArguments < Trailblazer::Operation
     def process(model, params)
@@ -238,7 +265,6 @@ class OperationTest < MiniTest::Spec
   end
 
   it { OperationReceivingLottaArguments.run(Object, {}).must_equal([true, [Object, {}]]) }
-
 
   # ::present only runs #setup! which runs #model!.
   class ContractOnlyOperation < Trailblazer::Operation
@@ -260,7 +286,6 @@ class OperationTest < MiniTest::Spec
   end
 
   it { ContractOnlyOperation.present({}).contract._model.must_equal Object }
-
 end
 
 class OperationBuilderTest < MiniTest::Spec

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -7,15 +7,14 @@ module Comparable
   end
 end
 
-class OperationRunTestt < MiniTest::Spec
-  class Operation1 < Trailblazer::Operation
+class OperationProcessParamsTest < MiniTest::Spec
+  class OperationProcessParam < Trailblazer::Operation
     # allow providing your own contract.
     self.contract_class = class Contract
       def initialize(*)
       end
       def validate(params)
-        return false if params[:valid] == false
-        "local #{params}"
+        params
       end
 
       def errors
@@ -36,8 +35,8 @@ class OperationRunTestt < MiniTest::Spec
     end
   end
 
-  let (:operation) { Operation1.new.extend(Comparable) }
-  it { Operation1.run({valid: true}).must_equal  ["local #{ {valid: true, garrett: "Rocks!"} }", operation] }
+  let (:operation) { OperationProcessParam.new.extend(Comparable) }
+  it { OperationProcessParam.run({valid: true}).must_equal  [{valid: true, garrett: "Rocks!"}, operation] }
 end
 
 class OperationRunTest < MiniTest::Spec


### PR DESCRIPTION
Allows for params to be mangled before `#process` is run within an Operation