### PR TITLE
Feature: Add operation collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/tmp
 test/version_tmp
 tmp
 /**/*.log
+vendor/bundle

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -83,6 +83,10 @@ module Trailblazer
     def valid?
       @valid
     end
+    
+    def to_model
+      @model
+    end
 
   private
     def setup!(*params)

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -45,6 +45,17 @@ module Trailblazer
       def contract(&block)
         contract_class.class_eval(&block)
       end
+      
+      def collection(*params, &block)
+        res, op = build_operation_class(*params).new.fetch_collection(*params)
+
+        if block_given?
+          yield op if res
+          return op
+        end
+
+        [res, op]
+      end
 
     private
       def build_operation_class(*params)
@@ -65,6 +76,18 @@ module Trailblazer
       setup!(*params) # where do we assign/find the model?
 
       [process(*params), valid?].reverse
+    end
+    
+    def fetch_collection(*params)
+      setup_collection!(*params)
+      
+      @collection = fetch(*params)
+
+      [self, valid?].reverse
+    end
+    
+    def collection
+      @collection
     end
 
     def present(*params)
@@ -89,6 +112,10 @@ module Trailblazer
     end
 
   private
+    def setup_collection!(*params)
+      setup_params!(*params)
+    end
+  
     def setup!(*params)
       setup_params!(*params)
 

--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -47,6 +47,7 @@ module Trailblazer
       end
       
       def collection(*params, &block)
+        *params = {} if params.empty?
         res, op = build_operation_class(*params).new.fetch_collection(*params)
 
         if block_given?
@@ -54,7 +55,7 @@ module Trailblazer
           return op
         end
 
-        [res, op]
+        op
       end
 
     private

--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -20,6 +20,7 @@ private
 
     Else.new(op, !res)
   end
+  alias_method :fetch, :collection
   
   # Doesn't run #validate.
   # TODO: allow only_setup.

--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -14,11 +14,12 @@ private
 
   def collection(operation_class, params=self.params, &block)
     @fetching_collection = true
-    res, op = operation!(operation_class, params) { operation_class.collection(params) }
+    op = operation!(operation_class, params) { operation_class.collection(params) }
+    @search = op.search if op.respond_to?(:search)
 
-    yield op if res and block_given?
+    yield op if block_given?
 
-    Else.new(op, !res)
+    Else.new(op)
   end
   alias_method :fetch, :collection
   
@@ -37,7 +38,7 @@ private
   # Note: this is not documented on purpose as this concept is experimental. I don't like it too much and prefer
   # returns in the valid block.
   class Else
-    def initialize(op, run)
+    def initialize(op, run = true)
       @op  = op
       @run = run
     end
@@ -80,15 +81,15 @@ private
       params.merge!(concept_name => request_body)
     end
 
-    res, @operation = yield # Create.run(params)
-
     if @fetching_collection
+      @operation = yield # Create.run(params)
       setup_operation_collection_variables!
+      @operation # DISCUSS: do we need result here? or can we just go pick op.valid?
     else
+      res, @operation = yield # Create.run(params)
       setup_operation_instance_variables!
+      [res, @operation] # DISCUSS: do we need result here? or can we just go pick op.valid?
     end
-
-    [res, @operation] # DISCUSS: do we need result here? or can we just go pick op.valid?
   end
 
   def setup_operation_instance_variables!

--- a/lib/trailblazer/operation/responder.rb
+++ b/lib/trailblazer/operation/responder.rb
@@ -19,6 +19,10 @@ module Trailblazer::Operation::Responder
   end
 
   def to_json(*)
-    self.class.representer_class.new(model).to_json
+    unless self.model.nil?
+      self.class.representer_class.new(model).to_json
+    else
+      self.collection.extend(self.class.representer_class.for_collection).to_json
+    end
   end
 end

--- a/lib/trailblazer/operation/worker.rb
+++ b/lib/trailblazer/operation/worker.rb
@@ -74,7 +74,7 @@ class Trailblazer::Operation
 
             # TODO: where do we set /tmp/uploads?
             dfn.merge!(
-              :serialize   => lambda { |file, *| Trailblazer::Operation::UploadedFile.new(file, :tmp_dir => "/tmp/uploads").to_hash },
+              :serialize   => lambda { |file, *| Trailblazer::Operation::UploadedFile.new(file, :tmp_dir => File.join(File.dirname(__FILE__), '../../..', 'tmp', 'uploads')).to_hash },
               :deserialize => lambda { |object, hash, *| Trailblazer::Operation::UploadedFile.from_hash(hash) },
               :class       => Hash
             )

--- a/test/crud_test.rb
+++ b/test/crud_test.rb
@@ -129,7 +129,7 @@ class CrudTest < MiniTest::Spec
     songs << CreateOperation[song: {title: "Blue Rondo a la Turk"}].model
     songs << CreateOperation[song: {title: "Mercy Day For Mr. Vengeance"}].model
     Song.all_records = songs
-    res, op = FetchCollectionOperation.collection({user_id: 0})
+    op = FetchCollectionOperation.collection({user_id: 0})
     op.collection.must_equal songs
   end
   
@@ -138,7 +138,7 @@ class CrudTest < MiniTest::Spec
     songs << CreateOperation[song: {title: "Blue Rondo a la Turk"}].model
     songs << CreateOperation[song: {title: "Mercy Day For Mr. Vengeance"}].model
     Song.all_records = songs
-    res, op = FetchCollectionOperation.collection({user_id: 99})
+    op = FetchCollectionOperation.collection({user_id: 99})
     op.collection.must_equal nil
   end
 

--- a/test/crud_test.rb
+++ b/test/crud_test.rb
@@ -5,9 +5,14 @@ class CrudTest < MiniTest::Spec
   Song = Struct.new(:title, :id) do
     class << self
       attr_accessor :find_result # TODO: eventually, replace with AR test.
+      attr_accessor :all_records
 
       def find(id)
         find_result
+      end
+      
+      def all
+        all_records
       end
     end
   end
@@ -99,6 +104,42 @@ class CrudTest < MiniTest::Spec
   it do
     Song.find_result = song = Song.new
     ModelUpdateOperation[{id: 1, song: {title: "Mercy Day For Mr. Vengeance"}}].model.must_equal song
+  end
+  
+  # model Song, :action
+  class FetchCollectionOperation < CreateOperation
+    model Song
+    
+    def fetch(params)
+      if @user_role == 'admin'
+        return Song.all
+      else
+        return nil
+      end
+    end
+    
+    def setup_params!(params)
+      @user_role = "admin" if params[:user_id] == 0
+    end
+  end
+
+  # allows ::model, :action.
+  it do
+    songs = []
+    songs << CreateOperation[song: {title: "Blue Rondo a la Turk"}].model
+    songs << CreateOperation[song: {title: "Mercy Day For Mr. Vengeance"}].model
+    Song.all_records = songs
+    res, op = FetchCollectionOperation.collection({user_id: 0})
+    op.collection.must_equal songs
+  end
+  
+  it do
+    songs = []
+    songs << CreateOperation[song: {title: "Blue Rondo a la Turk"}].model
+    songs << CreateOperation[song: {title: "Mercy Day For Mr. Vengeance"}].model
+    Song.all_records = songs
+    res, op = FetchCollectionOperation.collection({user_id: 99})
+    op.collection.must_equal nil
   end
 
 

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -170,6 +170,34 @@ class ControllerPresentTest < ActionController::TestCase
   end
 end
 
+#collection
+class ControllerCollectionTest < ActionController::TestCase
+  tests BandsController
+
+  # let (:band) { }
+
+  test "#collection" do
+    Band.destroy_all
+    Band::Create[band: {name: "Nofx"}]
+    Band::Create[band: {name: "Ramones"}]
+
+
+    get :index
+
+    assert_equal "bands/index.html: Nofx Ramones \n", response.body
+  end
+
+  # TODO: this implicitely tests builds. maybe have separate test for that?
+  test "#collection [JSON]" do
+    Band.destroy_all
+    Band::Create[band: {name: "Nofx"}]
+    Band::Create[band: {name: "Ramones"}]
+
+    get :index, format: :json
+    assert_equal "[{\"name\":\"Nofx\"},{\"name\":\"Ramones\"}]", response.body
+  end
+end
+
 # #form.
 class ControllerFormTest < ActionController::TestCase
   tests BandsController

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -158,7 +158,7 @@ class ControllerPresentTest < ActionController::TestCase
 
     get :show, id: band.id
 
-    assert_equal "bands/show.html: Band,Band,true,Band::Update,Essen\n", response.body
+    assert_equal "bands/show.html: Band,Band,true,Band::Update,Nofx", response.body
   end
 
   # TODO: this implicitely tests builds. maybe have separate test for that?

--- a/test/rails/fake_app/config.rb
+++ b/test/rails/fake_app/config.rb
@@ -1,3 +1,3 @@
 # database
 ActiveRecord::Base.configurations = {'test' => {:adapter => 'sqlite3', :database => ':memory:'}}
-ActiveRecord::Base.establish_connection('test')
+ActiveRecord::Base.establish_connection(:test)

--- a/test/rails/fake_app/controllers.rb
+++ b/test/rails/fake_app/controllers.rb
@@ -50,7 +50,11 @@ class BandsController < ApplicationController
       @klass    = op.model.class
       @locality = params[:band][:locality] unless params[:format] == "json"
 
-      render json: op.to_json if params[:format] == "json"
+      if params[:format] == "json"
+        render json: op.to_json
+      else
+        render text: "bands/show.html: #{@model.class},#{@klass},#{@form.is_a?(Reform::Form)},#{@operation.class},#{@operation.model.name}"
+      end
     end # render :show
   end
 

--- a/test/rails/fake_app/controllers.rb
+++ b/test/rails/fake_app/controllers.rb
@@ -7,9 +7,9 @@ class SongsController < ApplicationController
   respond_to :json, :js
 
   def index
-    @users = Song.all.page params[:page]
+    collection Song::Index(params[:page])
     render inline: <<-ERB
-<%= render_cell(:user, :show, @users) %>
+<%= render_cell(:user, :show, @songs) %>
 ERB
   end
 
@@ -44,6 +44,14 @@ end
 class BandsController < ApplicationController
   include Trailblazer::Operation::Controller
   respond_to :html, :json
+
+  def index
+    collection Band::Index do |op|
+      @klass    = op.model.class
+
+      render json: op.to_json if params[:format] == "json"
+    end # render :show
+  end
 
   def show
     present Band::Update do |op|
@@ -113,6 +121,12 @@ class ActiveRecordBandsController < ApplicationController
   include Trailblazer::Operation::Controller
   include Trailblazer::Operation::Controller::ActiveRecord
   respond_to :html
+
+  def index
+    collection Band::Index
+
+    render text: "active_record_bands/index.html: #{@collection.class}, #{@bands.class}, #{@operation.class}"
+  end
 
   def show
     present Band::Update

--- a/test/rails/fake_app/song/operations.rb
+++ b/test/rails/fake_app/song/operations.rb
@@ -101,4 +101,24 @@ class Band < ActiveRecord::Base
       JSON if params[:format] == "json"
     end
   end
+  
+  class Index < Create
+    
+    def fetch(params)
+      Band.all
+    end
+    
+    builds do |params|
+      JSON if params[:format] == "json"
+    end
+    
+    class JSON < self
+      module BandRepresenter
+        include Representable::JSON
+        property :name
+      end
+
+      self.representer_class = BandRepresenter
+    end
+  end
 end

--- a/test/rails/fake_app/views/bands/index.html.erb
+++ b/test/rails/fake_app/views/bands/index.html.erb
@@ -1,0 +1,1 @@
+bands/index.html: <% @collection.each do |element| %><%= "#{element.name} " %><% end %>

--- a/test/rails/test_helper.rb
+++ b/test/rails/test_helper.rb
@@ -1,4 +1,5 @@
 require 'trailblazer'
+require 'responders'
 require 'minitest/autorun'
 
 require 'fake_app/rails_app.rb'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,11 @@ require 'minitest/autorun'
 
 module TmpUploads
   extend ActiveSupport::Concern
+  fs_dir = File.join(File.dirname(__FILE__), '..', 'tmp', 'uploads')
+  FileUtils.mkdir_p(fs_dir) unless File.exist?(fs_dir)
 
   included do
-    let (:tmp_dir) { "/tmp/uploads" }
-    before { Dir.mkdir(tmp_dir) unless File.exists?(tmp_dir) }
+    let(:tmp_dir) { File.expand_path(fs_dir) }
   end
 end
 

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -74,7 +74,7 @@ class UploadedFileTest < MiniTest::Spec
       }
 
       it { @subject.must_match /\w+_trailblazer_upload$/ }
-      it { @subject.must_match /^\/tmp\/uploads\// }
+      it { @subject.must_match /^#{tmp_dir}/ }
 
       it { File.exists?(@subject).must_equal true }
       it { File.size(@subject).must_equal image.size }

--- a/trailblazer.gemspec
+++ b/trailblazer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   # spec.add_development_dependency "minitest-spec-rails" # TODO: can anyone make this work (test/rails).
+  spec.add_development_dependency "responders"
   spec.add_development_dependency "sidekiq", "~> 3.1.0"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
Add #collection to operation, so on Controller::index just need to:

```ruby
class Controller < ApplicationController
  def index
    collection Thing::Index
  end
end
```

And a @collection and @things variable will be set with the collection returned by the operation.

To implement, just need to:

```ruby
class Thing < ActiveRecord::Base
  class Index
    def fetch(*params)
  end
end
```

`setup_collection!` is calling `setup_params!` too, if need to make some tweak on the params.

JSON serialization is working perfectly too, just the syntax is a little bit weird (not so compatible with trbrb way) as can see on this [test](https://github.com/apotonick/trailblazer/blob/bf5ca2aac928dab0b853243fe2fb1f166030c19c/test/rails/fake_app/song/operations.rb#L116)

```ruby
class JSON < self
  module BandRepresenter
    include Representable::JSON
    property :name
  end

  self.representer_class = BandRepresenter
end
```

This should be more like the representer DSL but after many hours going deeper on Representable, I could only do so

### Bonus:

When runned the tests under rails with `rake rails` task, many tests were broken, so:
* I [fixed](https://github.com/apotonick/trailblazer/commit/36f87c263e8fa8bd6a6c4fe6861e35e631365729) [them](https://github.com/apotonick/trailblazer/commit/b36525cbcb8aea140d5be487af507462f1270729)
* [removed AR deprecation](https://github.com/apotonick/trailblazer/commit/42b55dd2e52a6b5e8438d263421799963a57c1f6)
* [Added responders gem](https://github.com/apotonick/trailblazer/commit/d2e118d90c7f5d40ce0a149bca736da75256850d) to run tests