### PR TITLE
Feature: Add collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/version_tmp
 tmp
 /**/*.log
 vendor/bundle
+vendor/cache

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/tmp
 test/version_tmp
 tmp
 /**/*.log
+vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
+  - 2.2.0
   - 2.1.2
   - 2.0.0
   - 1.9.3
-script:
-  - bundle exec rake test
-  - bundle exec rake rails

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,28 @@
+# 0.3.0
+
+## Changes
+
+* In Railtie, use `ActionDispatch::Reloader.to_prepare` for autoloading, nothing else. This should fix spring reloading.
+* Allow `Op#validate(params, model, Contract)` with CRUD.
+* Allows prefixed table names, e.g. `admin.users` in `Controller`. The instance variables will be `@user`. Thanks to @fernandes and especially @HuckyDucky.
+
+## API change
+
+1. The return value of #process is no longer returned from ::run and ::call. they always return the operation instance.
+2. The return value of #validate is true or false. this allows a more intuitive operation body.
+
+    ```ruby
+    def process(params)
+      if validate(params)
+        .. do valid
+      else
+        .. handle invalid
+      end
+    end
+    ```
+
 # 0.2.3
 
-* Fix autoloading problems with spring by simplifying it.
 
 # 0.2.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 # gem "representable", path: "../representable"
 # gem "reform", path: "../reform"
 # gem "reform", git: "https://github.com/apotonick/reform.git"
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,23 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-task :default => [:test]
+task :default => [:build]
+default_task = Rake::Task[:build]
+
 Rake::TestTask.new(:test) do |test|
   test.libs << 'test'
   test.test_files = FileList['test/*_test.rb']
   test.verbose = true
 end
 
+# this how the rails test must be run: BUNDLE_GEMFILE=gemfiles/Gemfile.rails bundle exec rake rails
 Rake::TestTask.new(:rails) do |test|
   test.libs << 'test/rails'
   test.test_files = FileList['test/rails/*_test.rb']
   test.verbose = true
 end
+
+rails_task = Rake::Task["rails"]
+test_task = Rake::Task["test"]
+default_task.enhance { test_task.invoke }
+default_task.enhance { rails_task.invoke }

--- a/lib/trailblazer/autoloading.rb
+++ b/lib/trailblazer/autoloading.rb
@@ -1,5 +1,5 @@
 Trailblazer::Operation.class_eval do
   autoload :Controller, 'trailblazer/operation/controller'
-  autoload :Responder,  'trailblazer/operation/responder'
   autoload :CRUD,       'trailblazer/operation/crud'
+  autoload :Responder,  'trailblazer/operation/responder'
 end

--- a/lib/trailblazer/operation/controller/active_record.rb
+++ b/lib/trailblazer/operation/controller/active_record.rb
@@ -7,6 +7,6 @@ private
   end
 
   def operation_model_name
-    @model.class.table_name.singularize
+    @model.class.table_name.split(".").last.singularize
   end
 end

--- a/lib/trailblazer/operation/crud.rb
+++ b/lib/trailblazer/operation/crud.rb
@@ -39,8 +39,8 @@ module Trailblazer
 
 
       # #validate no longer accepts a model since this module instantiates it for you.
-      def validate(params, *args)
-        super(params, @model, *args)
+      def validate(params, model=self.model, *args)
+        super(params, model, *args)
       end
 
     private
@@ -61,7 +61,6 @@ module Trailblazer
       end
 
       alias_method :find_model, :update_model
-
 
       # Rails-specific.
       # ActiveModel will automatically call Form::model when creating the contract and passes

--- a/lib/trailblazer/operation/dispatch.rb
+++ b/lib/trailblazer/operation/dispatch.rb
@@ -1,0 +1,21 @@
+module Trailblazer::Operation::Dispatch
+  module ClassMethods
+    def skip_dispatch(callback_name)
+      _skip_dispatch << callback_name
+    end
+  end
+
+  def self.included(base)
+    base.extend ClassMethods
+
+    base.extend Uber::InheritableAttr
+    base.inheritable_attr :_skip_dispatch
+    base._skip_dispatch = []
+  end
+
+
+  def dispatch(callback_name, *args)
+    return if self.class._skip_dispatch.include?(callback_name)
+    send(callback_name, *args)
+  end
+end

--- a/lib/trailblazer/operation/responder.rb
+++ b/lib/trailblazer/operation/responder.rb
@@ -19,6 +19,11 @@ module Trailblazer::Operation::Responder
   end
 
   def to_json(*)
+    return self.collection.extend(self.class.representer_class.for_collection).to_json if self.collection
     self.class.representer_class.new(model).to_json
+  end
+
+  def to_model
+    @model
   end
 end

--- a/lib/trailblazer/operation/worker.rb
+++ b/lib/trailblazer/operation/worker.rb
@@ -94,3 +94,4 @@ class Trailblazer::Operation
     end
   end
 end
+

--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -1,6 +1,6 @@
 module Trailblazer
   class Railtie < Rails::Railtie
-    def self.autoload_crud_operations(app)
+    def self.autoload_operations(app)
       Dir.glob("app/concepts/**/crud.rb") do |f|
         path  = f.sub("app/concepts/", "")
         model = path.sub("/crud.rb", "")
@@ -10,12 +10,19 @@ module Trailblazer
       end
     end
 
+    def self.autoload_cells(app)
+      Dir.glob("app/concepts/**/*cell.rb") do |f|
+        require_dependency "#{app.root}/#{f}" # load app/concepts/{concept}/cell.rb.
+      end
+    end
+
     # thank you, http://stackoverflow.com/a/17573888/465070
     initializer 'trailblazer.install', after: :load_config_initializers do |app|
       # the trb autoloading has to be run after initializers have been loaded, so we can tweak inclusion of features in
       # initializers.
       ActionDispatch::Reloader.to_prepare do
-        Trailblazer::Railtie.autoload_crud_operations(app)
+        Trailblazer::Railtie.autoload_operations(app)
+        Trailblazer::Railtie.autoload_cells(app)
       end
     end
   end

--- a/lib/trailblazer/version.rb
+++ b/lib/trailblazer/version.rb
@@ -1,3 +1,3 @@
 module Trailblazer
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/test/dispatch_test.rb
+++ b/test/dispatch_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class OperationCallbackTest < MiniTest::Spec
+  class Create < Trailblazer::Operation
+    include Dispatch
+
+    def process(params)
+      dispatch :notify_me!
+      dispatch :notify_you!, params
+
+      # TODO:
+      # dispatch :notify_whoever, Callable
+      # dispatch :notify_whoever, lambda { |args| block }
+      self
+    end
+
+    def dispatched
+      @dispatched ||= []
+    end
+
+  private
+    def notify_me!
+      dispatched << :notify_me!
+    end
+
+    def notify_you!(params)
+      dispatched << :notify_you!
+    end
+  end
+
+
+  class Update < Create
+    skip_dispatch :notify_me!
+  end
+
+
+  it "invokes all callbacks" do
+    op = Create.({})
+    op.dispatched.must_equal [:notify_me!, :notify_you!]
+  end
+
+  it "does not invoke skipped callbacks" do
+    op = Update.({})
+    op.dispatched.must_equal [:notify_you!]
+  end
+end

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -52,10 +52,22 @@ class ResponderRespondTest < ActionController::TestCase
     assert_redirected_to song_path(Song.last)
   end
 
+  test "Create [html/valid/location]" do
+    post :other_create, {song: {title: "You're Going Down"}}
+    assert_redirected_to other_create_songs_path
+  end
+
   test "Create [html/invalid]" do
     post :create, {song: {title: ""}}
     assert_response 200
     assert_equal @response.body, "{:title=&gt;[&quot;can&#39;t be blank&quot;]}"
+  end
+
+  test "Create [html/invalid/action]" do
+    post :other_create, {song: {title: ""}}
+    assert_response 200
+    assert_equal @response.body, "OTHER SONG\n{:title=&gt;[&quot;can&#39;t be blank&quot;]}\n"
+    assert_template "songs/another_view"
   end
 
   test "Delete [html/valid]" do
@@ -170,6 +182,34 @@ class ControllerPresentTest < ActionController::TestCase
   end
 end
 
+#collection
+class ControllerCollectionTest < ActionController::TestCase
+  tests BandsController
+
+  # let (:band) { }
+
+  test "#collection" do
+    Band.destroy_all
+    Band::Create[band: {name: "Nofx"}]
+    Band::Create[band: {name: "Ramones"}]
+
+
+    get :index
+
+    assert_equal "bands/index.html: Nofx Ramones \n", response.body
+  end
+
+  # TODO: this implicitely tests builds. maybe have separate test for that?
+  test "#collection [JSON]" do
+    Band.destroy_all
+    Band::Create[band: {name: "Nofx"}]
+    Band::Create[band: {name: "Ramones"}]
+
+    get :index, format: :json
+    assert_equal "[{\"name\":\"Nofx\"},{\"name\":\"Ramones\"}]", response.body
+  end
+end
+
 # #form.
 class ControllerFormTest < ActionController::TestCase
   tests BandsController
@@ -204,3 +244,15 @@ class ActiveRecordPresentTest < ActionController::TestCase
     assert_equal "active_record_bands/show.html: Band, Band, true, Band::Update", response.body
   end
 end
+
+class PrefixedTablenameControllerTest < ActionController::TestCase
+  tests TenantsController
+
+  test "show" do
+    tenant = Tenant.create(name: "My Tenant") # yepp, I am not using an operation! blasphemy!!!
+    get :show, id: tenant.id
+
+    assert_equal "My Tenant", response.body
+  end
+end
+

--- a/test/rails/fake_app/config.rb
+++ b/test/rails/fake_app/config.rb
@@ -1,3 +1,3 @@
 # database
 ActiveRecord::Base.configurations = {'test' => {:adapter => 'sqlite3', :database => ':memory:'}}
-ActiveRecord::Base.establish_connection('test')
+ActiveRecord::Base.establish_connection(:test)

--- a/test/rails/fake_app/models.rb
+++ b/test/rails/fake_app/models.rb
@@ -6,6 +6,10 @@ class Band < ActiveRecord::Base
   has_many :songs
 end
 
+class Tenant < ActiveRecord::Base
+  self.table_name = 'public.tenants'
+end
+
 # migrations
 class CreateAllTables < ActiveRecord::Migration
   def self.up
@@ -19,7 +23,12 @@ class CreateAllTables < ActiveRecord::Migration
       t.string :name
       t.string :locality
     end
+
+    create_table(:"public.tenants") do |t|
+      t.string :name
+    end
   end
 end
 ActiveRecord::Migration.verbose = false
 CreateAllTables.up
+

--- a/test/rails/fake_app/rails_app.rb
+++ b/test/rails/fake_app/rails_app.rb
@@ -22,12 +22,14 @@ app.initialize!
 
 # routes
 app.routes.draw do
+
   resources :songs do
     member do # argh.
       delete :destroy_with_formats
     end
 
     collection do
+      post :other_create
       post :create_with_params
       post :create_with_block
     end
@@ -45,6 +47,8 @@ app.routes.draw do
       post :update_with_block
     end
   end
+
+  resources :tenants, only: [:show]
 end
 
 require 'trailblazer/operation/responder'

--- a/test/rails/fake_app/song/operations.rb
+++ b/test/rails/fake_app/song/operations.rb
@@ -101,4 +101,34 @@ class Band < ActiveRecord::Base
       JSON if params[:format] == "json"
     end
   end
+  
+  class Index < Create
+    
+    def setup_model!(params)
+      @collection = Band.all
+      super
+    end
+    
+    builds do |params|
+      JSON if params[:format] == "json"
+    end
+    
+    class JSON < self
+      module BandRepresenter
+        include Representable::JSON
+        property :name
+        property :locality
+      end
+
+      self.representer_class = BandRepresenter
+    end
+  end
 end
+
+class Tenant < ActiveRecord::Base
+  class Show < Trailblazer::Operation
+    include CRUD
+    model Tenant, :update
+  end
+end
+

--- a/test/rails/fake_app/views/bands/index.html.erb
+++ b/test/rails/fake_app/views/bands/index.html.erb
@@ -1,0 +1,1 @@
+bands/index.html: <% @collection.each do |element| %><%= "#{element.name} " %><% end %>

--- a/test/rails/fake_app/views/songs/another_view.html.erb
+++ b/test/rails/fake_app/views/songs/another_view.html.erb
@@ -1,0 +1,2 @@
+OTHER SONG
+<%= @form.errors.to_s %>

--- a/test/rails/test_helper.rb
+++ b/test/rails/test_helper.rb
@@ -1,4 +1,5 @@
 require 'trailblazer'
+require 'responders'
 require 'minitest/autorun'
 
 require 'fake_app/rails_app.rb'

--- a/test/responder_test.rb
+++ b/test/responder_test.rb
@@ -10,8 +10,7 @@ class Song
     include Responder
 
     def process(params)
-      invalid!(self) if params == false
-      self
+      invalid! if params == false
     end
   end
 end
@@ -26,8 +25,7 @@ module MyApp
       model Song
 
       def process(params)
-        invalid!(self) if params == false
-        self
+        invalid! if params == false
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,54 @@
 require 'trailblazer'
 require 'minitest/autorun'
+require 'active_record'
+require 'database_cleaner'
+
+# ActiveRecord Connection
+# ActiveRecord::Base.logger = Logger.new(STDERR)
+ActiveRecord::Base.logger = false
+ActiveRecord::Base.establish_connection(
+  adapter:  "sqlite3",
+  database: ":memory:"
+)
+
+# Dot not show Active Record Migrations
+ActiveRecord::Migration.verbose = false
+ActiveRecord::Schema.define do
+  create_table :things do |table|
+    table.column :title, :string
+    table.column :active, :boolean, default: true
+  end
+  
+  create_table(:bands) do |table|
+    table.column :name, :string
+    table.column :locality, :string
+  end
+end
 
 module TmpUploads
   extend ActiveSupport::Concern
+  fs_dir = File.join(File.dirname(__FILE__), '..', 'tmp', 'uploads')
+  FileUtils.mkdir_p(fs_dir) unless File.exist?(fs_dir)
 
   included do
-    let (:tmp_dir) { "/tmp/uploads" }
-    before { Dir.mkdir(tmp_dir) unless File.exists?(tmp_dir) }
+    let(:tmp_dir) { File.expand_path(fs_dir) }
   end
 end
 
 MiniTest::Spec.class_eval do
   include TmpUploads
+end
+
+# Database Cleaning
+DatabaseCleaner.strategy = :transaction
+DatabaseCleaner.clean_with(:truncation)
+
+class MiniTest::Spec
+  before :each do
+    DatabaseCleaner.start
+  end
+
+  after :each do
+    DatabaseCleaner.clean
+  end
 end

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -74,7 +74,7 @@ class UploadedFileTest < MiniTest::Spec
       }
 
       it { @subject.must_match /\w+_trailblazer_upload$/ }
-      it { @subject.must_match /^\/tmp\/uploads\// }
+      it { @subject.must_match /^#{tmp_dir}/ }
 
       it { File.exists?(@subject).must_equal true }
       it { File.size(@subject).must_equal image.size }

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -87,8 +87,10 @@ class WorkerFileMarshallerTest < MiniTest::Spec
     include Worker::FileMarshaller # should be ContractFileMarshaller
 
     def process(params)
-      params
+      @params = params
     end
+
+    attr_reader :params
   end
 
   # TODO: no image
@@ -104,7 +106,9 @@ class WorkerFileMarshallerTest < MiniTest::Spec
 
     args["album"]["image"]["filename"].must_equal "cells.png"
 
-    _, params = Operation.perform_one # deserialize.
+    _, op = Operation.perform_one # deserialize.
+
+    params = op.params
 
     params["title"].must_equal("Dragonfly")
     params[:title].must_equal("Dragonfly") # must allow indifferent_access.

--- a/trailblazer.gemspec
+++ b/trailblazer.gemspec
@@ -19,14 +19,16 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack", '>= 3.0.0' # this framework works on Rails.
+  spec.add_dependency "representable", ">= 2.1.1", "<2.3.0" # Representable::apply.
+  spec.add_dependency "reform", ">= 1.2.0"
   spec.add_dependency "uber", ">= 0.0.10" # no builder inheritance.
-  spec.add_dependency "representable", ">= 2.1.1", "<2.2.0" # Representable::apply.
-  spec.add_dependency "reform", "~> 1.2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   # spec.add_development_dependency "minitest-spec-rails" # TODO: can anyone make this work (test/rails).
+  spec.add_development_dependency "responders"
   spec.add_development_dependency "sidekiq", "~> 3.1.0"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
Imagine every time you want perform a search or a scope, you need to code on `process` method... not anymore!

This PR add support for scopes (thanks Ransack) and pagination (thanks Kaminari)

How does it work? On your controller to get a collection you do (for more info check https://github.com/apotonick/trailblazer/pull/36):

```ruby
def index
  collection Thing::Index
end
```

On your operation you need to:

```ruby
class Thing < ActiveRecord::Base
  class Index < Trailblazer::Operation
    # including CRUD and setting model is needed for both Scope and Pagination
    include CRUD, Scope, Pagination
    model Thing
  end
end
```

In your request you need to pass:

* `params[:q]` based on Ransack, check its [basic searching page](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching) for more information about it

* `params[:page]` for what page you want and `params[:per_page]` for how many results per page will be shown

And thats it... scope and pagination out of the box! :laughing:
