### PR TITLE
add some configs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,16 @@ You can just add
 
 ```ruby
 require "trailblazer/autoloading"
+
+Trailblazer::Operation::CRUD.module_eval do
+  module Included
+    def included(base)
+      super
+      base.send :include, Trailblazer::Operation::CRUD::ActiveModel
+    end
+  end
+  extend Included
+end
 ```
 
 to `config/initializers/trailblazer.rb` and implementation classes like `Operation` will be automatically loaded.


### PR DESCRIPTION
When I follow your readme, all my form objects are named "reform". When I added this new configs everything worked fine!

Example without this configurations: 
```ruby
@form.model_name
=> #<ActiveModel::Name:0x007f83961c14b8 @name="Reform", @klass=#<Class:0x007f8397072340>, @singular="reform", @plural="reforms", @element="reform", @human="Reform", @collection="reforms", @param_key="reform", @i18n_key=:reform, @route_key="reforms", @singular_route_key="reform">
```

Example with this configuration:
```ruby
@form.model_name
=> #<ActiveModel::Name:0x007f8915ae9070 @name="Comment", @klass=#<Class:0x007f8911dd3a78>, @singular="comment", @plural="comments", @element="comment", @human="Comment", @collection="comments", @param_key="comment", @i18n_key=:comment, @route_key="comments", @singular_route_key="comment">
```