### PR TITLE
Add support for respond_with options

### DIFF
--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -47,11 +47,11 @@ private
   end
 
   # The block passed to #respond is always run, regardless of the validity result.
-  def respond(operation_class, params=self.params, &block)
+  def respond(operation_class, params=self.params, respond_options = {}, &block)
     res, op = operation!(operation_class, params) { operation_class.run(params) }
 
-    return respond_with op if not block_given?
-    respond_with op, &Proc.new { |formats| block.call(op, formats) } if block_given?
+    return respond_with op, respond_options if not block_given?
+    respond_with op, respond_options, &Proc.new { |formats| block.call(op, formats) } if block_given?
   end
 
   def process_params!(params)

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -52,10 +52,22 @@ class ResponderRespondTest < ActionController::TestCase
     assert_redirected_to song_path(Song.last)
   end
 
+  test "Create [html/valid/location]" do
+    post :other_create, {song: {title: "You're Going Down"}}
+    assert_redirected_to other_song_path
+  end
+
   test "Create [html/invalid]" do
     post :create, {song: {title: ""}}
     assert_response 200
     assert_equal @response.body, "{:title=&gt;[&quot;can&#39;t be blank&quot;]}"
+  end
+
+  test "Create [html/invalid/action]" do
+    post :other_create, {song: {title: ""}}
+    assert_response 200
+    assert_equal @response.body, "OTHER SONG\n{:title=&gt;[&quot;can&#39;t be blank&quot;]}\n"
+    assert_template "songs/another_view"
   end
 
   test "Delete [html/valid]" do

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -54,7 +54,7 @@ class ResponderRespondTest < ActionController::TestCase
 
   test "Create [html/valid/location]" do
     post :other_create, {song: {title: "You're Going Down"}}
-    assert_redirected_to other_song_path
+    assert_redirected_to other_create_songs_path
   end
 
   test "Create [html/invalid]" do

--- a/test/rails/fake_app/controllers.rb
+++ b/test/rails/fake_app/controllers.rb
@@ -20,6 +20,10 @@ ERB
     respond Song::Create
   end
 
+  def other_create
+    respond Song::Create, params, { location: other_song_path, action: :another_view }
+  end
+
   def create_with_params
     respond Song::Create, song: {title: "A Beautiful Indifference"}
   end

--- a/test/rails/fake_app/controllers.rb
+++ b/test/rails/fake_app/controllers.rb
@@ -21,7 +21,7 @@ ERB
   end
 
   def other_create
-    respond Song::Create, params, { location: other_song_path, action: :another_view }
+    respond Song::Create, params, { location: other_create_songs_path, action: :another_view }
   end
 
   def create_with_params

--- a/test/rails/fake_app/rails_app.rb
+++ b/test/rails/fake_app/rails_app.rb
@@ -22,6 +22,10 @@ app.initialize!
 
 # routes
 app.routes.draw do
+  post "other_song", to: "songs#other_create"
+  get "other_song/:id", to: "songs#other_show"
+  get "other_song/new", to: "songs#other_new"
+
   resources :songs do
     member do # argh.
       delete :destroy_with_formats

--- a/test/rails/fake_app/rails_app.rb
+++ b/test/rails/fake_app/rails_app.rb
@@ -22,9 +22,6 @@ app.initialize!
 
 # routes
 app.routes.draw do
-  post "other_song", to: "songs#other_create"
-  get "other_song/:id", to: "songs#other_show"
-  get "other_song/new", to: "songs#other_new"
 
   resources :songs do
     member do # argh.
@@ -32,6 +29,7 @@ app.routes.draw do
     end
 
     collection do
+      post :other_create
       post :create_with_params
       post :create_with_block
     end

--- a/test/rails/fake_app/views/songs/another_view.html.erb
+++ b/test/rails/fake_app/views/songs/another_view.html.erb
@@ -1,0 +1,2 @@
+OTHER SONG
+<%= @form.errors.to_s %>


### PR DESCRIPTION
If you need to specify respond_with location or action for example use in your controller:

```ruby
respond_with Model, params, { location: new_location, action: :action }
```

`params` need to be specified because is a optional argument on respond and I wouldn't like to change method signature, so just added responder options