### PR TITLE
Set right variable name when using Controller::AR

### DIFF
--- a/lib/trailblazer/operation/controller/active_record.rb
+++ b/lib/trailblazer/operation/controller/active_record.rb
@@ -8,7 +8,7 @@ private
 
   def operation_model_name
     # set the right variable name if collection
-    if @model.class.to_s.match(/ActiveRecord_Relation\z/)
+    if @operation.is_a?(Trailblazer::Operation::Collection)
       return @model.model.table_name.split(".").last
     end
     @model.class.table_name.split(".").last.singularize

--- a/lib/trailblazer/operation/controller/active_record.rb
+++ b/lib/trailblazer/operation/controller/active_record.rb
@@ -7,6 +7,10 @@ private
   end
 
   def operation_model_name
+    # set the right variable name if collection
+    if @model.class.to_s.match(/ActiveRecord_Relation\z/)
+      return @model.model.table_name.split(".").last
+    end
     @model.class.table_name.split(".").last.singularize
   end
 end

--- a/test/rails/controller_test.rb
+++ b/test/rails/controller_test.rb
@@ -233,6 +233,15 @@ class ActiveRecordPresentTest < ActionController::TestCase
 
     assert_equal "active_record_bands/show.html: Band, Band, true, Band::Update", response.body
   end
+
+  test "#collection" do
+    Band.destroy_all
+    Band::Create[band: {name: "Nofx"}]
+
+    get :index
+
+    assert_equal "active_record_bands/index.html: Band::ActiveRecord_Relation, Band::ActiveRecord_Relation, Band::Index", response.body
+  end
 end
 
 class PrefixedTablenameControllerTest < ActionController::TestCase


### PR DESCRIPTION
When using `Controller::ActiveRecord` it tries to set the variable name according to table name, but when we are using collection there is no way of doing this automatically because `@model` is a _ActiveRecord_Relation_ so what is proposed is to check if `@model` is a relation then set the right variable name.

This case was not supported on first collection commit because wasn't being tested the case that a controller include AR module, now its being covered and with tests.