### PR TITLE
autoloading for NotAuthorizedError

### DIFF
--- a/lib/trailblazer/autoloading.rb
+++ b/lib/trailblazer/autoloading.rb
@@ -1,3 +1,7 @@
+Trailblazer.class_eval do
+  autoload :NotAuthorizedError, "trailblazer/operation/policy"
+end
+
 Trailblazer::Operation.class_eval do
   autoload :Controller, "trailblazer/operation/controller"
   autoload :Model,      "trailblazer/operation/model"


### PR DESCRIPTION
This helps to have a `ApplicationController` like this:
```ruby
class ApplicationController < ActionController::Base
  rescue_from Trailblazer::NotAuthorizedError do |exception|
    redirect_to root_path, alert: exception.message
  end
end
```