### PR TITLE
Raise exception when validation run with nil. Fixes #85

### DIFF
--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -117,6 +117,7 @@ module Trailblazer
     include Setup
 
     def validate(params, model=nil, contract_class=nil)
+      raise ParameterMissing if params.nil?
       contract!(model, contract_class)
 
       if @valid = validate_contract(params)
@@ -156,6 +157,8 @@ module Trailblazer
     end
 
     class InvalidContract < RuntimeError
+    end
+    class ParameterMissing < RuntimeError
     end
   end
 end

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -247,4 +247,8 @@ class OperationErrorsTest < MiniTest::Spec
     res, op = Operation.run({})
     op.errors.to_s.must_equal "{:title=>[\"can't be blank\"]}"
   end
+
+  it do
+    lambda { Operation.run(nil) }.must_raise Trailblazer::Operation::ParameterMissing
+  end
 end


### PR DESCRIPTION
This is most likely going to show up when the parameter is missing

```
def process(params)
  validate(params[:comment]) do
  ...
  end
end
```

Since this is an application error, not a user input error, it's reasonable to raise an exception.