### PR TITLE
Feature discussion: How to best implement model-less operations

### DIFF
--- a/lib/trailblazer/autoloading.rb
+++ b/lib/trailblazer/autoloading.rb
@@ -5,6 +5,7 @@ end
 Trailblazer::Operation.class_eval do
   autoload :Controller, "trailblazer/operation/controller"
   autoload :Model,      "trailblazer/operation/model"
+  autoload :Modelless,  "trailblazer/operation/modelless"
   autoload :Collection, "trailblazer/operation/collection"
   autoload :Dispatch,   "trailblazer/operation/dispatch"
   autoload :Module,     "trailblazer/operation/module"

--- a/lib/trailblazer/operation/modelless.rb
+++ b/lib/trailblazer/operation/modelless.rb
@@ -1,0 +1,14 @@
+module Trailblazer
+  class Operation
+    module Modelless
+      def model!(params)
+        NullModel.new
+      end
+
+      class NullModel
+        def method_missing(*)
+        end
+      end
+    end
+  end
+end

--- a/test/modelless_test.rb
+++ b/test/modelless_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'trailblazer/operation'
+require 'trailblazer/operation/modelless'
+
+class ModellessTest < MiniTest::Spec
+  class CreateOperation < Trailblazer::Operation
+    include Modelless
+
+    contract do
+      property :email
+      validates :email, presence: true
+    end
+
+    def process(params)
+      validate(params[:contact]) do |f|
+        f.save do |data|
+          params[:process].(data)
+        end
+      end
+    end
+  end
+
+
+  # processes the data for you.
+  it do
+    CreateOperation.(contact: {email: "visitor@example.com"},
+                     process: ->(data) { data.must_equal "email" => "visitor@example.com" })
+  end
+
+  # doesn't process invalid data
+  it do
+    assert_raises(Trailblazer::Operation::InvalidContract) { CreateOperation.(contact: {}) }
+  end
+end


### PR DESCRIPTION
There are use cases for implementing a operation that doesn't save the data to a model but still benefits from the form validation and the separation of HTTP logic and business logic such as a contact form on a home page that sends an email, or a sign in page that creates a session.

Let's discuss how this can best be achieved in Trailblazer and if we reach a consensus, let's document that method in the README and other resources.

One way that @acaron suggested is to use a null object for the model by including a `Modelless` module into the operation (I implemented `Modelless` in the commit for this PR):

```ruby
module ContactForm
  class Create < Trailblazer::Operation
    include Trailblazer::Operation::Modelless

    contract do
      property :name, validates: { presence: true }
      property :email, validates: { presence: true }
    end

    private

    def process(params)
      validate(params[:contact_form]) do |f|
        f.save do |data|
          send_system_email(data)
        end
      end
    end

    def send_system_email(data)
      # ...
    end
  end
end
```

Another way is to force all properties to be `virtual`:

```ruby
module ContactForm
  class Create < Trailblazer::Operation
    contract do
      property :name, validates: { presence: true }, virtual: true
      property :email, validates: { presence: true }, virtual: true
    end

    private

    def process(params)
      validate(params[:contact_form]) do |f|
        f.save do |data|
          send_system_email(data)
        end
      end
    end

    def send_system_email(data)
      # ...
    end
  end
end
```

Another way is to have the model be an `OpenStruct`:

```ruby
require 'ostruct'

module ContactForm
  class Create < Trailblazer::Operation

    contract do
      property :name, validates: { presence: true }
      property :email, validates: { presence: true }
    end

    private

    def model!(*)
      OpenStruct.new
    end

    def process(params)
      validate(params[:contact_form]) do |f|
        f.save do |data|
          send_system_email(data)
        end
      end
    end

    def send_system_email(data)
      # ...
    end
  end
end
```

Which way do you prefer? Do you have a better way of making an operation that doesn't need an actual model?

Currently these 3 proposals all use `f.save { |data| ... }`. Do you have a suggestion to simplify this piece?

