### PR TITLE
Don't discard the options when calling

### DIFF
--- a/lib/trailblazer/operation/controller.rb
+++ b/lib/trailblazer/operation/controller.rb
@@ -11,7 +11,7 @@ private
   # Provides the operation instance, model and contract without running #process.
   # Returns the operation.
   def present(operation_class, options={})
-    operation!(operation_class, skip_form: true)
+    operation!(operation_class, options.merge(skip_form: true))
   end
 
   def collection(*args)


### PR DESCRIPTION
When calling `Trailblazer::Operation::Controller#present` we were discarding the `options` param and just sending `skip_form: true` instead.

This PR now merges `skip_form: true` into the existing options hash