### PR TITLE
Allow Operation#@model to be set via private setter method

### DIFF
--- a/lib/trailblazer/operation.rb
+++ b/lib/trailblazer/operation.rb
@@ -88,6 +88,8 @@ module Trailblazer
 
   private
     module Setup
+      attr_writer :model
+
       def setup!(params)
         params = assign_params!(params)
         setup_params!(params)

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -10,7 +10,7 @@ end
 class OperationSetupParamsTest < MiniTest::Spec
   class OperationSetupParam < Trailblazer::Operation
     def process(params)
-      @model = params
+      self.model = params
     end
 
     def setup_params!(params)
@@ -27,7 +27,7 @@ end
 class OperationParamsTest < MiniTest::Spec
   class Operation < Trailblazer::Operation
     def process(params)
-      @model = "#{params} and #{@params==params}"
+      self.model = "#{params} and #{@params==params}"
     end
 
     def params!(params)

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -10,7 +10,7 @@ end
 class OperationSetupParamsTest < MiniTest::Spec
   class OperationSetupParam < Trailblazer::Operation
     def process(params)
-      self.model = params
+      @model = params
     end
 
     def setup_params!(params)
@@ -27,7 +27,7 @@ end
 class OperationParamsTest < MiniTest::Spec
   class Operation < Trailblazer::Operation
     def process(params)
-      self.model = "#{params} and #{@params==params}"
+      @model = "#{params} and #{@params==params}"
     end
 
     def params!(params)

--- a/test/operation_test.rb
+++ b/test/operation_test.rb
@@ -54,6 +54,21 @@ class OperationModelTest < MiniTest::Spec
   it { Operation.(Object).model.must_equal Object }
 end
 
+# Operation#model=.
+class OperationModelEqualsTest < MiniTest::Spec
+  class Operation < Trailblazer::Operation
+    def process(params)
+      self.model = "#{params} and #{@params==params}"
+    end
+
+    def params!(params)
+      { params: params }
+    end
+  end
+
+  # allows you returning new params in #params!.
+  it { Operation.("I can set @model via a private setter").model.to_s.must_equal "{:params=>\"I can set @model via a private setter\"} and true" }
+end
 
 class OperationRunTest < MiniTest::Spec
   class Operation < Trailblazer::Operation


### PR DESCRIPTION
As discussed at the RubyConfAU 2016 workshop on Trailblazer, it sucks to have to set `@model` in an Operation via direct ivar assignment. We should be able to use a private `attr_writer` :)