### PR TITLE
Adds a few attr_readers to NotAuthorizedError which is useful for API's

### DIFF
--- a/lib/trailblazer/operation/policy.rb
+++ b/lib/trailblazer/operation/policy.rb
@@ -2,6 +2,21 @@ require "trailblazer/operation/policy/guard"
 
 module Trailblazer
   class NotAuthorizedError < RuntimeError
+    attr_reader :query, :record, :policy
+
+    def initialize(options = {})
+      if options.is_a? String
+        message = options
+      else
+        @query  = options[:query]
+        @record = options[:record]
+        @policy = options[:policy]
+
+        message = options.fetch(:message) { "not allowed to #{query} this #{record.inspect}" }
+      end
+
+      super(message)
+    end
   end
 
   # Adds #evaluate_policy to #setup!, and ::policy.


### PR DESCRIPTION
This was copied directly from Pundit::NotAuthorizedError and is generally useful.